### PR TITLE
Remove the ## at the bottom of the page

### DIFF
--- a/modules/tutorials/pages/pattern-matching/multiple-hop-and-accumulation.adoc
+++ b/modules/tutorials/pages/pattern-matching/multiple-hop-and-accumulation.adoc
@@ -759,4 +759,3 @@ INTERPRET QUERY () SYNTAX v2 {
 }
 ----
 
-##


### PR DESCRIPTION
Looks like there might have been some edits for a new header using ## but never got added. Removed the ## from the end of the page.