### PR TITLE
Adding open Cypher docs/pages to GSQL Docs

### DIFF
--- a/modules/appendix/nav.adoc
+++ b/modules/appendix/nav.adoc
@@ -9,5 +9,6 @@
 ** xref:common-errors-and-problems.adoc[]
 ** xref:openCypher-in-gsql.adoc[]
 ** xref:openCypher-in-gsql-web-shell.adoc[]
+** xref:openCypher-gsql-from-clause-extension.adoc[]
 ** xref:cheat-sheets.adoc[]
 ** xref:notations.adoc[]

--- a/modules/appendix/nav.adoc
+++ b/modules/appendix/nav.adoc
@@ -7,5 +7,7 @@
 ** xref:gsql-start-to-end-process.adoc[]
 ** xref:example-graphs.adoc[]
 ** xref:common-errors-and-problems.adoc[]
+** xref:openCypher-in-gsql.adoc[]
+** xref:openCypher-in-gsql-web-shell.adoc[]
 ** xref:cheat-sheets.adoc[]
 ** xref:notations.adoc[]

--- a/modules/appendix/pages/openCypher-gsql-from-clause-extension.adoc
+++ b/modules/appendix/pages/openCypher-gsql-from-clause-extension.adoc
@@ -20,7 +20,7 @@ Both `v` and `VType` are optional.
 
 Both `e` and `EType` are optional.
 
-`EType` can be a disjunction
+`EType` can be a disjunction.
 
 == openCypher's property condition notation
 
@@ -71,7 +71,7 @@ CREATE  QUERY test_07 () FOR GRAPH G SYNTAX _V2 {
 }
 
 
-NOTE:: If the original input is V2 or V1, the cypher preprocessor is never invoked, so it will not affect standard GSQL queries.
+NOTE: If the original input is V2 or V1, the cypher preprocessor is never invoked, so it will not affect standard GSQL queries.
 
 == More examples below:
 

--- a/modules/appendix/pages/openCypher-gsql-from-clause-extension.adoc
+++ b/modules/appendix/pages/openCypher-gsql-from-clause-extension.adoc
@@ -1,12 +1,12 @@
-= Cypher Pattern Support in GSQL
+= openCypher Pattern Support in GSQL
 
-We have extended GSQL to support Cypher patterns in the FROM clause.
+We have extended GSQL to support openCypher patterns in the FROM clause.
 
-GSQL maintains its SELECT-FROM-WHERE block structure, but TigerGraph now allows the following new syntax in the FROM clause
+GSQL maintains its SELECT-FROM-WHERE block structure, but TigerGraph allows the following new syntax in the FROM clause
 
 NOTE: This is in addition to the standard GSQL patterns, which will continue to be supported
 
-== Cypher's vertex pattern notation
+== openCypher's vertex pattern notation
 
 `(v:VType)` which now gets translated internally to standard GSQL's  `VType:v`.
 
@@ -14,7 +14,7 @@ Both `v` and `VType` are optional.
 
 `VType` can be a disjunction.
 
-== Cypher's edge patterns notation
+== openCypher's edge patterns notation
 
 `[e:EType]` which now gets translated internally to standard GSQL's `(EType:e)`.
 
@@ -22,13 +22,13 @@ Both `e` and `EType` are optional.
 
 `EType` can be a disjunction
 
-== Cypher's property condition notation
+== openCypher's property condition notation
 
-This is applicable to both vertex and edge patterns. It has a general form:
+GSQL also handles openCypher's property condition notation (which is applicable to both vertex and edge patterns)
 
     x {prop_1: val_1, …, prop_n: val_n}
 
-and it now gets translated internally into a `WHERE` clause condition:
+by translating into a `WHERE` clause condition:
 
     x.prop_1 == val_1 AND … AND x.prop_n == val_n
 

--- a/modules/appendix/pages/openCypher-gsql-from-clause-extension.adoc
+++ b/modules/appendix/pages/openCypher-gsql-from-clause-extension.adoc
@@ -1,0 +1,324 @@
+= Cypher Pattern Support in GSQL
+
+We have extended GSQL to support Cypher patterns in the FROM clause.
+
+GSQL maintains its SELECT-FROM-WHERE block structure, but TigerGraph now allows the following new syntax in the FROM clause
+
+NOTE: This is in addition to the standard GSQL patterns, which will continue to be supported
+
+== Cypher's vertex pattern notation
+
+`(v:VType)` which now gets translated internally to standard GSQL's  `VType:v`.
+
+Both `v` and `VType` are optional.
+
+`VType` can be a disjunction.
+
+== Cypher's edge patterns notation
+
+`[e:EType]` which now gets translated internally to standard GSQL's `(EType:e)`.
+
+Both `e` and `EType` are optional.
+
+`EType` can be a disjunction
+
+== Cypher's property condition notation
+
+This is applicable to both vertex and edge patterns. It has a general form:
+
+    x {prop_1: val_1, …, prop_n: val_n}
+
+and it now gets translated internally into a `WHERE` clause condition:
+
+    x.prop_1 == val_1 AND … AND x.prop_n == val_n
+
+== Examples
+
+[source, gsql]
+CREATE  QUERY test_03 () FOR GRAPH G SYNTAX V3 {
+    SELECT n, COUNT(fr) AS friendsCount INTO T
+    FROM (n {name: "John"})-[:FRIEND]-(fr)
+    HAVING friendsCount > 3;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_07 () FOR GRAPH G SYNTAX V3 {
+    SELECT friend_of_a_friend.name AS fofName INTO T
+    FROM (user:Person {name: "Adam"})-[r1:FRIEND]-()-[r2:FRIEND]-(friend_of_a_friend) ;
+    PRINT T;
+}
+
+NOTE: For queries with cypher patterns to be accepted, the user needs to declare them under V3 syntax (using cypher patterns with V2 or V1 syntax declaration leads to syntax error). V3 queries are pre-processed into V2 queries (the V2 version is written to the log after the cypher pattern normalization).
+
+
+[source, gsql]
+CREATE QUERY test_03 () FOR GRAPH G SYNTAX V2 {
+    SELECT n, COUNT(fr) AS friendsCount INTO T
+    from   :n -(FRIEND)- :fr  WHERE n.name == "John"
+    HAVING friendsCount > 3;
+    PRINT T;
+}
+
+Now after cypher pattern normalization:
+
+[source, gsql]
+CREATE  QUERY test_07 () FOR GRAPH G SYNTAX _V2 {
+    SELECT friend_of_a_friend.name AS fofName INTO T
+    from   Person:user -(FRIEND:r1)-  -(FRIEND:r2)- :friend_of_a_friend
+    WHERE user.name == "Adam" ;
+    PRINT T;
+}
+
+
+NOTE:: If the original input is V2 or V1, the cypher preprocessor is never invoked, so it will not affect standard GSQL queries.
+
+== More examples below:
+
+[source, gsql]
+CREATE  QUERY test_03 () FOR GRAPH G SYNTAX V3 {
+    XXX =
+    SELECT  n
+    FROM    (n)-[:friend]-(fr);
+    PRINT XXX;
+}
+
+[source, gsql]
+CREATE  QUERY test_99 () FOR GRAPH G SYNTAX V3 {
+    SELECT  n.name INTO T  FROM  (n)
+    ORDER BY n.name
+    LIMIT 3;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_98 () FOR GRAPH G SYNTAX V3 {
+    SELECT  n.name INTO T  FROM  (n)
+    ORDER BY n.name
+    LIMIT 3;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_40 () FOR GRAPH G SYNTAX V3
+{
+    SELECT
+    CASE
+        WHEN n.eyes == "blue" THEN 1
+        WHEN n.age < 40 THEN 2
+    ELSE 3 END AS result INTO T  FROM  (n) ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_40a () FOR GRAPH G SYNTAX V3 {
+    SELECT
+    CASE n.eyes
+        WHEN "blue" THEN 1
+        WHEN "brown" THEN 2
+    ELSE 3 END AS result INTO T  FROM  (n) ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_22 () FOR GRAPH G SYNTAX V3 {
+    SELECT actor, count(movie) AS nrOfMovies INTO T
+    FROM (actor:Person)-[:ACTED_IN]->(movie:Movie);
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_21 () FOR GRAPH G SYNTAX V3 {
+    SELECT actor.name, actor.age INTO T
+    FROM  (actor:Person {name: "Charlie Sheen"})-[:ACTED_IN]->(movie:Movie);
+}
+
+[source, gsql]
+CREATE  QUERY test_195b () FOR GRAPH G SYNTAX V3 {
+    SELECT  n INTO T  FROM  (n) WHERE n.email == "//This is NOT a comment";
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_164 () FOR GRAPH G SYNTAX V3 {
+    SELECT  a.type  INTO T  FROM  (a)
+    WHERE a.name == "Alice";
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_162 () FOR GRAPH G SYNTAX V3 {
+    SELECT  sum(n.age) INTO T  FROM  (n:Person) ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_161 () FOR GRAPH G SYNTAX V3 {
+    SELECT n.age INTO T  FROM  (n)
+    WHERE n.name IN ("A" "B" "C");
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_158 () FOR GRAPH G SYNTAX V3 {
+    SELECT  min(n.age) INTO T  FROM  (n:Person) ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_157 () FOR GRAPH G SYNTAX V3 {
+    SELECT  min(n.age) INTO T  FROM  (n:Person) ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_156 () FOR GRAPH G SYNTAX V3 {
+    SELECT  max(n.age) INTO T  FROM  (n:Person) ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_154b () FOR GRAPH G SYNTAX V3 {
+    SELECT  count(n.age) INTO T  FROM  (n:Person) ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_154a () FOR GRAPH G SYNTAX V3 {
+    SELECT  count(n.age) INTO T  FROM  (n:Person) ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_153 () FOR GRAPH G SYNTAX V3 {
+    SELECT  n.type , n.age, count(*) INTO T  FROM  (n {name: "A"})-[]->(x) ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_153b () FOR GRAPH G SYNTAX V3 {
+    SELECT  r.type , count(*) INTO T  FROM  (n {name: "A"})-[r]->() ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_153a () FOR GRAPH G SYNTAX V3 {
+    SELECT  r.type , count(*) INTO T  FROM  (n {name: "A"})-[r]->() ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_151 () FOR GRAPH G SYNTAX V3 {
+    SELECT  avg(n.age) INTO T  FROM  (n:Person) ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_149 () FOR GRAPH G SYNTAX V3 {
+    SELECT  r.type  INTO T  FROM  (n)-[r]->()
+    WHERE n.name == "Alice";
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_145 () FOR GRAPH G SYNTAX V3 {
+    SELECT  length(a.name) INTO T  FROM  (a)
+    WHERE length(a.name)> 6;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_141 () FOR GRAPH G SYNTAX V3 {
+    SELECT  getvid(a) INTO T  FROM  (a) ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_12 () FOR GRAPH G SYNTAX V3 {
+    SELECT  remote_friend.name INTO T  FROM  (me)-[:KNOWS*1..2]-(remote_friend)
+    WHERE me.name == "Filipa";
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_107 () FOR GRAPH G SYNTAX V3 {
+    DELETE n   FROM  (n:Person {name: "Andres"}) ;
+}
+
+[source, gsql]
+CREATE  QUERY test_107a () FOR GRAPH G SYNTAX V3 {
+    DELETE r   FROM  (n {name: "Andres"})-[r:KNOWS]->() ;
+}
+
+[source, gsql]
+CREATE  QUERY test_104 () FOR GRAPH G SYNTAX V3 {
+    DELETE n   FROM  (n:Person) ;
+}
+
+[source, gsql]
+CREATE  QUERY test_08 () FOR GRAPH G SYNTAX V3 {
+    SELECT friend_of_a_friend.name AS fofName INTO T
+    FROM   (fr)-[r2:friend]-(friend_of_a_friend) ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_07 () FOR GRAPH G SYNTAX V3 {
+    SELECT friend_of_a_friend.name AS fofName INTO T
+    FROM   (user:Person {name: "Adam"})-[r1:friend]-()-[r2:friend]-(friend_of_a_friend) ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_07a () FOR GRAPH G SYNTAX V3 {
+    SELECT friend_of_a_friend.name AS fofName INTO T
+    FROM   (fr)-[r2:friend]-(friend_of_a_friend) ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_03 () FOR GRAPH G SYNTAX V3 {
+    SELECT  n, COUNT(fr) AS friendsCount INTO T
+    FROM    (n {name: "John"})-[:friend]-(fr)
+    HAVING  friendsCount > 3;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_154 () FOR GRAPH G SYNTAX V3 {
+    SELECT  count(x) INTO T  FROM  (n {name: "A"})-[]->(x) ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_multiple_match_where() FOR GRAPH G SYNTAX V3 {
+    SELECT  n, count(f) AS fCount, count(fof) AS fofCount INTO T
+    FROM    (n {name: "John"})-[:friend]-(f), (f)-[:friend]-(fof)
+    WHERE   f.age < 21 AND  fof.age < 21
+    HAVING  fCount > 3 AND fofCount > 13;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_kleened_wildcard() FOR GRAPH G SYNTAX V3 {
+    SELECT DISTINCT p, hollywood INTO T
+    FROM   (p:Person {name: "Kevin Bacon"})-[:_*1..3]-(hollywood) ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_kleene_no_type() FOR GRAPH G SYNTAX V3 {
+    SELECT DISTINCT p, hollywood INTO T
+    FROM   (p:Person {name: "Kevin Bacon"})-[*1..3]-(hollywood) ;
+    PRINT T;
+}
+
+[source, gsql]
+CREATE  QUERY test_empty_edge_pattern_right() FOR GRAPH G SYNTAX V3 {
+    SELECT DISTINCT p, x INTO T
+    FROM   (p:Person {name: "Kevin Bacon"}) --> (x) ;
+    PRINT T;
+}
+
+
+

--- a/modules/appendix/pages/openCypher-in-gsql-web-shell.adoc
+++ b/modules/appendix/pages/openCypher-in-gsql-web-shell.adoc
@@ -2,16 +2,16 @@
 
 To write openCypher queries in the GSQL Web Shell, follow these steps:
 
-NOTE: Interpret query does not support distributed query mode
+NOTE: INTERPRET QUERY does not support distributed query mode
 
-. Open GSQL Web Shell in your browser and login.
+. Open GSQL Web Shell in your browser and log in.
 
 . Run `INTERPRET OPENCYPHER QUERY`
 [source,gsql]
 INTERPRET OPENCYPHER QUERY () FOR GRAPH communication_mau {
 MATCH (u:user)
 WHERE u.id = "test"
-Return u
+RETURN u
 }
 
 . Create an openCypher query
@@ -19,13 +19,15 @@ Return u
 CREATE DISTRIBUTED OPENCYPHER QUERY get_user_by_id2() FOR GRAPH communication_mau {
 MATCH (u:user)
 WHERE u.id = "test"
-Return u
+RETURN u
 }
 
 . Install the openCypher query
 [source,gsql]
 INSTALL QUERY get_user_by_id2
-Run installed openCypher query
+
+. Run installed openCypher query
+[source, gsql]
 RUN QUERY get_user_by_id2()
 
 

--- a/modules/appendix/pages/openCypher-in-gsql-web-shell.adoc
+++ b/modules/appendix/pages/openCypher-in-gsql-web-shell.adoc
@@ -1,0 +1,31 @@
+= Writing openCypher Queries in GSQL Web Shell
+
+To write openCypher queries in the GSQL Web Shell, follow these steps:
+
+NOTE: Interpret query does not support distributed query mode
+
+. Open GSQL Web Shell in your browser and login.
+
+. Run `INTERPRET OPENCYPHER QUERY`
+[source,gsql]
+INTERPRET OPENCYPHER QUERY () FOR GRAPH communication_mau {
+MATCH (u:user)
+WHERE u.id = "test"
+Return u
+}
+
+. Create an openCypher query
+[source,gsql]
+CREATE DISTRIBUTED OPENCYPHER QUERY get_user_by_id2() FOR GRAPH communication_mau {
+MATCH (u:user)
+WHERE u.id = "test"
+Return u
+}
+
+. Install the openCypher query
+[source,gsql]
+INSTALL QUERY get_user_by_id2
+Run installed openCypher query
+RUN QUERY get_user_by_id2()
+
+

--- a/modules/appendix/pages/openCypher-in-gsql.adoc
+++ b/modules/appendix/pages/openCypher-in-gsql.adoc
@@ -1,0 +1,315 @@
+= openCypher Features in GSQL
+
+We support many openCypher features in TigerGraph but not all.
+
+This page lists all of openCypher features that are currently *supported* and *unsupported* by TigerGraph.
+
+== Supported openCypher Features
+=== Clauses
+
+[cols="1,1"]
+|===
+|Clause |Description
+
+|DELETE | Delete graph elements — nodes and relationships.
+
+Any node to be deleted must also have all associated relationships explicitly deleted.
+
+|DETACH DELETE |Writing Delete a node or set of nodes.
+
+All associated relationships will automatically be deleted.
+
+|LIMIT |Reading sub-clause A sub-clause used to constrain the number of records in the output.
+
+|MATCH |Reading Specify the patterns to search for in the database.
+
+|MANDATORY MATCH |Reading Specify the patterns to search for in the database, and fail if no match is found.
+
+|ORDER BY [ASC[ENDING] DESC[ENDING]] |Reading sub-clause A sub-clause following
+
+|RETURN or WITH |Specifying that the output should be sorted in either ascending (the default) or descending order.
+
+|RETURN … [AS] |Projecting Defines what to include in the query result set.
+
+|SKIP |Reading/Writing A sub-clause defining from which record to start including the records in the output.
+
+|WITH … [AS] |Projecting Allows query parts to be chained together, piping the results from one to be used as starting points or criteria in the next.
+
+See below for restrictions.
+
+|WHERE |Reading sub-clause A sub-clause used to add constraints to the patterns in a MATCH clause, or to filter the results of a WITH clause.
+|===
+
+=== Operators
+[cols="1,1"]
+|===
+|% |Mathematical Modulo division
+
+|* |Mathematical Multiplication
+
+|+ |Mathematical Addition
+
+|+ |String Concatenation
+
+|+ |List Concatenation
+
+|- |Mathematical Subtraction or unary minus
+
+|. |General Property access
+
+|/ |Mathematical Division
+
+|< |Comparison Less than
+
+|< = |Comparison Less than or equal to
+
+|<> |Comparison Inequality
+
+|= |Comparison Equality
+
+|> |Comparison Greater than
+
+|>= |Comparison Greater than or equal to
+
+|AND |Boolean Conjunction
+
+|CONTAINS |String comparison Case-sensitive inclusion search
+
+|DISTINCT |General Duplicate removal
+
+|ENDS WITH |String comparison Case-sensitive suffix search
+
+|IN List |List element existence check
+
+|IS NOT NULL |Comparison Non-null check
+
+|IS NULL |Comparison null check
+
+|NOT |Boolean Negation
+
+|OR |Boolean Disjunction
+
+|STARTS WITH |String comparison Case-sensitive prefix search
+
+|XOR |Boolean Exclusive disjunction
+
+|[ ] |General Subscript (dynamic property access)
+
+|[ ] |List Subscript (accessing element(s) in a list)
+
+|^ |Mathematical Exponentiation
+|===
+
+=== Functions
+
+[cols="1,1"]
+|===
+|left() |String Returns a string containing the specified number of leftmost characters of the original string.
+
+|right() |String Returns a string containing the specified number of rightmost characters of the original string.
+
+|reverse() |String Returns a string in which the order of all characters in the original string have been reversed.
+
+|lTrim() |String Returns the original string with leading whitespace removed.
+
+|replace() |String Returns a string in which all occurrences of a specified string in the original string have been replaced by another (specified) string.
+
+|rTrim() |String Returns the original string with trailing whitespace removed.
+
+|trim() |String Returns the original string with leading and trailing whitespace removed.
+
+|acos() |Trigonometric Returns the arccosine of a number in radians.
+
+|asin() |Trigonometric Returns the arcsine of a number in radians.
+
+|atan() |Trigonometric Returns the arctangent of a number in radians.
+
+|atan2() |Trigonometric Returns the arctangent2 of a set of coordinates in radians.
+
+|ceil() |Numeric Returns the smallest floating point number that is greater than or equal to a number and equal to a mathematical integer.
+
+|cot() |Trigonometric Returns the cotangent of a number.
+
+|degrees() |Trigonometric Converts radians to degrees.
+
+|exp() |Logarithmic Returns e^n, where e is the base of the natural logarithm, and n is the value of the argument expression.
+
+|floor() |Numeric Returns the largest floating point number that is less than or equal to a number and equal to a mathematical integer.
+
+|log() |Logarithmic Returns the natural logarithm of a number.
+
+|log10() |Logarithmic Returns the common logarithm (base 10) of a number.
+
+|pi() |Trigonometric Returns the mathematical constant pi.
+
+|radians() |Trigonometric Converts degrees to radians.
+
+|rand() |Numeric Returns a random floating point number in the range from 0 (inclusive) to 1 (exclusive); i.e. [0, 1).
+
+|round() |Numeric Returns the value of a number rounded to the nearest integer.
+
+|sign() |Numeric Returns the signum of a number: 0 if the number is 0, -1 for any negative number, and 1 for any positive number.
+
+|sin() |Trigonometric Returns the sine of a number.
+
+|sqrt() |Logarithmic Returns the square root of a number.
+
+|stDev() |Aggregating Returns the standard deviation for the given value over a group for a sample of a population.
+
+|tan() |Trigonometric Returns the tangent of a number.
+
+|abs() |Numeric Returns the absolute value of a number.
+
+|avg() |Aggregating Returns the average of a set of values.
+
+|coalesce() |Scalar Returns the first non-null value in a list of expressions.
+
+|cos() |Trigonometric Returns the cosine of a number.
+
+|count() |Aggregating Returns the number of values or records.
+
+|max() |Aggregating Returns the maximum value in a set of values.
+
+|min() |Aggregating Returns the minimum value in a set of values.
+
+|sum() |Aggregating Returns the sum of a set of numeric values.
+
+|type() |Scalar Returns the string representation of the relationship type.
+
+|toLower() |String Returns the original string in lowercase.
+
+|toString() |String Converts an integer, float or boolean value to a string.
+
+|toUpper() |String Returns the original string in uppercase.
+
+|substring() |String Returns a substring of the original string, beginning with a 0-based index start and length.
+
+|e() |Logarithmic Returns the base of the natural logarithm, e.
+
+|timestamp() |Scalar Returns the difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC.
+|===
+
+=== Expressions
+[cols="1,1"]
+|===
+|CASE Expression |A generic conditional expression, similar to if/else statements available in other languages.
+|===
+
+== Unsupported openCypher Features
+=== Clauses
+[cols="1,1]
+|===
+|OPTIONAL MATCH |Reading Specify the patterns to search for in the database while using nulls for missing parts of the pattern.
+
+|CALL […YIELD] |Reading/Writing Invoke a procedure deployed in the database.
+
+|CREATE |Writing create nodes and relationships.
+
+|MERGE |Reading/Writing Ensures that a pattern exists in the graph. Either the pattern already exists, or it needs to be created.
+
+|REMOVE |Writing Remove properties and labels from nodes and relationships.
+
+|UNION |Set operations Combines the result of multiple queries. Duplicates are removed.
+
+|UNION ALL |Set operations Combines the result of multiple queries. Duplicates are retained.
+
+|UNWIND … [AS] |Projecting Expands a list into a sequence of records.
+
+|SET |Writing Update labels on nodes and properties on nodes and relationships.
+|===
+
+=== Operators
+N/A
+
+=== Functions
+[cols="1,1"]
+|===
+|collect() |Aggregating Returns a list containing the values returned by an expression.
+
+|endNode() |Scalar Returns the end node of a relationship.
+
+|exists() |Predicate Returns true if a match for the pattern exists in the graph, or if the specified property exists in the node, relationship or map.
+
+|head() |Scalar Returns the first element in a list.
+
+|id() |Scalar Returns the id of a relationship or node.
+
+|keys() |List Returns a list containing the string representations for all the property names of a node, relationship, or map.
+
+|labels() |List Returns a list containing the string representations for all the labels of a node.
+
+|last() |Scalar Returns the last element in a list.
+
+|length() |Scalar Returns the length of a path.
+
+|nodes() |List Returns a list containing all the nodes in a path.
+
+|properties() |Scalar Returns a map containing all the properties of a node or relationship.
+
+|range() |List Returns a list comprising all integer values within a specified range.
+
+|relationships() |List Returns a list containing all the relationships in a path.
+
+|size() |Scalar Returns the number of items in a list.
+
+|size() |Applied to pattern expression Scalar Returns the number of subgraphs matching the pattern expression. size() applied to string Scalar Returns the size of a string.
+
+|split() |String Returns a list of strings resulting from the splitting of the original string around matches of the given delimiter.
+
+|startNode() |Scalar Returns the start node of a relationship.
+
+|tail() |List Returns all but the first element in a list.
+
+|reverse() |List Returns a list in which the order of all elements in the original list have been reversed.
+
+|stDevP() |Aggregating Returns the standard deviation for the given value over a group for an entire population → coming soon
+
+|percentileCont() |Aggregating Returns the percentile of the given value over a group using linear interpolation.
+
+|percentileDisc() |Aggregating Returns the nearest value to the given percentile over a group using a rounding method.
+
+|toBoolean() |Scalar Converts a string value to a boolean value.
+
+|toFloat() |Scalar Converts an integer or string value to a floating point number.
+
+|toInteger() |Scalar Converts a floating point or string value to an integer value.
+|===
+
+=== Syntax
+
+Certain openCypher syntax is also *not* supported.
+
+* Queries with a *WITH* clause that *does not* implicitly group by exactly one vertex variable.
+
+. 0 vertex variables as group key
+[source,gsql]
+MATCH (u:User {name: "John") // find all users with the same friend count as John
+WITH     u.friendCount AS fc   // note, u not included in group key list
+MATCH  (o:User {friendCount: fc})
+…
+
+. More than 1 vertex variables as group key
+[source,gsql]
+MATCH (u1) -[:communication]- (x) -[:communication]- (u2)
+WITH     u1, u2, COUNT(x) // we support only u1 or only u2 in list
+…
+
+* Queries introducing path variables
+[source,gsql]
+MATCH p = (u1) -[e1:communication]- (x) -[e2:communication]- (u2)	// p is path var
+…
+
+* Queries whose *MATCH* pattern *does not* include at least one vertex variable from immediately preceding *WITH* clause.
+[source,gsql]
+MATCH (u:user) -[:communication]- (o)
+WITH     u, …
+MATCH (x) -[:communication]-(y)		// this pattern must refer to u
+…
+
+* Queries with disconnected *MATCH* pattern fragments
+[source,gsql]
+MATCH (x:user), (y:user)
+WHERE x.friendCount = y.friendCount
+…
+
+* Pattern fragments (x:user) and (y:user) *are not* connected by edge traversal or by sharing vertex variables.

--- a/modules/appendix/pages/openCypher-in-gsql.adoc
+++ b/modules/appendix/pages/openCypher-in-gsql.adoc
@@ -1,17 +1,18 @@
-= openCypher Features in GSQL
+= openCypher in GSQL
 
-We support many openCypher features in TigerGraph but not all.
 
-This page lists all of openCypher features that are currently *supported* and *unsupported* by TigerGraph.
+openCypher is a popular open-source declarative query language for property graphs. More about openCypher can be found at xref:http://opencypher.org[openCypher.org].
 
-== Supported openCypher Features
+TigerGraph's GSQL query language supports many openCypher features. This page lists the features currently xref:_opencypher_features_in_gsql[supported] and features xref:_opencypher_features_not_yet_supported[not yet supported ].
+
+== openCypher Features in GSQL
 === Clauses
 
 [cols="1,1"]
 |===
 |Clause |Description
 
-|DELETE | Delete graph elements — nodes and relationships.
+|DELETE |Delete graph elements — nodes and relationships.
 
 Any node to be deleted must also have all associated relationships explicitly deleted.
 
@@ -195,7 +196,7 @@ See below for restrictions.
 |CASE Expression |A generic conditional expression, similar to if/else statements available in other languages.
 |===
 
-== Unsupported openCypher Features
+== openCypher Features Not Yet Supported
 === Clauses
 [cols="1,1]
 |===

--- a/modules/querying/pages/query-operations.adoc
+++ b/modules/querying/pages/query-operations.adoc
@@ -154,6 +154,8 @@ It also supports calling functions, assigning variables, printing, and modifying
 +
 The query body may include calls to other queries. That is, the other queries are treated as subquery functions.
 See the subsection on "xref:querying:operators-and-expressions.adoc#_subqueries[subqueries]".
++
+Additionally, GSQL supports openCypher syntax in the query body. See pages xref:appendix:openCypher-in-gsql.adoc[], xref:appendix:openCypher-in-gsql-web-shell.adoc[], and xref:appendix:openCypher-gsql-from-clause-extension.adoc[] to learn more about openCypher and for examples.
 
 === Examples
 

--- a/modules/querying/pages/select-statement/select-statement-v1.adoc
+++ b/modules/querying/pages/select-statement/select-statement-v1.adoc
@@ -46,6 +46,8 @@ image::select_statement_data_flow_v1.1.png[Basic data flow for a classic 1-hop G
 
 In classic (Syntax v1) GSQL, the FROM clause describes one step or hop pattern.
 
+NOTE: As of 3.9.3, GSQL supports openCypher patterns as an alternative to writing a FROM clause. Please see xref:appendix:openCypher-gsql-from-clause-extension.adoc[] for more details.
+
 .FROM clause
 [source,ebnf]
 ----


### PR DESCRIPTION
Associated task(s): 
https://graphsql.atlassian.net/browse/DOC-1837 
https://graphsql.atlassian.net/browse/DOC-1866

This pull requests adds documentation for the openCypher support in our current documentation.
-adds three pages
-- openCypher-in-gsql.adoc
-- openCypher-in-gsql-web-shell.adoc
-- openCypher-gsql-from-clause-extension.adoc


