### PR TITLE
Adding -max_loading_error option and update to docs

### DIFF
--- a/modules/ddl-and-loading/pages/running-a-loading-job.adoc
+++ b/modules/ddl-and-loading/pages/running-a-loading-job.adoc
@@ -87,18 +87,20 @@ The special symbol `$` is interpreted as "last line", so `-n 10,$` means reads f
 
 ==== `-max_percent_error mpe`
 
-The `-max_percent_error` option instructs the loader process to abort the loading job if the percentage of data lines in the input batch that are rejected exceeds `mpe`.
-By default, `mbe` is set to 100 and loading will continue until complete.
+The `-max_percent_error` option instructs the loader process to abort the loading job, if the percentage (range between 0 and 100) of data lines in the input batch that are rejected, exceeds `mpe`.
+By default, loading will continue until complete, which is equivalent to `mbe` being set to 100.
 
 Otherwise, for example, if the input source has 1000 data lines and `mpe` = 25 (or 25%),
 then the loading job will abort if it rejects 251 lines.
 
-If mpe = 0, then the load job aborts if any input line is rejected.
+If mpe = 0, then the load job aborts if any input line are rejected.
 
 There are two possible cases where an input line may be rejected:
 
 * Input format error: the input line cannot be parsed properly.
 * Filtering error: the input line can be parsed properly, but it does not pass certain filtering rules defined in the loading job itself.
+
+The percentage number following `-max_percent_error` **is required** if the option is provided. Otherwise, a parsing error will appear.
 
 === Parameters
 

--- a/modules/ddl-and-loading/pages/running-a-loading-job.adoc
+++ b/modules/ddl-and-loading/pages/running-a-loading-job.adoc
@@ -45,7 +45,7 @@ For more information, see xref:tigergraph-server:user-access:access-control-mode
 .`RUN LOADING JOB` syntax for concurrent loading
 [source.wrap,ebnf]
 ----
-RUN LOADING JOB [-noprint] [-dryrun] [-n [i],j] job_name [
+RUN LOADING JOB [-noprint] [-dryrun] [-n [i],j] [-max_percent_error [100] ] job_name [
     USING file_var [="file_path_string"][, file_var [="file_path_string"]]*
     [, CONCURRENCY=cnum][,BATCH_SIZE=bnum][,EOF="eof_mode"]
 ]
@@ -84,6 +84,31 @@ The `-n` option limits the loading job to processing only a range of lines of ea
 For example, `-n 50` means read lines 1 to 50.
 `-n 10, 50` means read lines 10 to 50.
 The special symbol `$` is interpreted as "last line", so `-n 10,$` means reads from line 10 to the end.
+
+==== `-max_percent_error`
+
+The `-max_percent_error` option is used by the loader process to decide when to automatically abort a running loading job.
+This depends on a user provided percentage of the data input lines that are rejected.
+
+There are two possible cases where an input line may be rejected:
+
+* Input format error: This is the case where the input line cannot be parsed properly.
+* Filtering error: This is the case where the input line can be parsed properly, but it does not pass certain filtering rules defined in the loading job itself.
+
+For example, if `-max_percent_error` is set to 50%, and over 50% of data input lines in a given batch are rejected by the loader either due to parsing error or filtering error, the loader process will abort itself.
+
+NOTE: The default behavior is 100% and will continue loading until reaching the end of the file.
+
+[cols="2"]
+|===
+|max_percent_error |behavior
+
+|0 |Loading will stop if any parsed input lines are rejected by the format or filtering rules.
+
+|between 0 and 99 |Loading will stop if the percentage of rejected parsed input exceeds the user-provided limit.
+
+|100 |Loading will continue until complete.
+|===
 
 === Parameters
 

--- a/modules/ddl-and-loading/pages/running-a-loading-job.adoc
+++ b/modules/ddl-and-loading/pages/running-a-loading-job.adoc
@@ -97,8 +97,9 @@ There are two possible cases where an input line may be rejected:
 
 For example, if `-max_percent_error` is set to 50%, and over 50% of data input lines in a given batch are rejected by the loader either due to parsing error or filtering error, the loader process will abort itself.
 
-NOTE: The default behavior is 100% and will continue loading until reaching the end of the file.
+NOTE: The default percentage is set to 0.
 
+.`-max_percent_error` summery
 [cols="2"]
 |===
 |max_percent_error |behavior

--- a/modules/ddl-and-loading/pages/running-a-loading-job.adoc
+++ b/modules/ddl-and-loading/pages/running-a-loading-job.adoc
@@ -45,8 +45,10 @@ For more information, see xref:tigergraph-server:user-access:access-control-mode
 .`RUN LOADING JOB` syntax for concurrent loading
 [source.wrap,ebnf]
 ----
-RUN LOADING JOB [-noprint] [-dryrun] [-n [i],j] [-max_percent_error [100] ] job_name [
-    USING file_var [="file_path_string"][, file_var [="file_path_string"]]*
+RUN LOADING JOB [-noprint] [-dryrun] [-n [i],j] [-max_percent_error mbe ]
+job_name [
+    USING file_var [="file_path_string"]
+        [, file_var [="file_path_string"]]*
     [, CONCURRENCY=cnum][,BATCH_SIZE=bnum][,EOF="eof_mode"]
 ]
 ----
@@ -71,8 +73,6 @@ Kick off the following job:
   Loading log: '/usr/local/tigergraph/logs/restpp/restpp_loader_logs/gsql_demo/gsql_demo_m1.1525091090494.log'
 ----
 
-
-
 ==== `-dryrun`
 
 If -dryrun is used, the system will read the data files and process the data as instructed by the job, but will NOT load any data into the graph. This option can be a useful diagnostic tool.
@@ -85,31 +85,20 @@ For example, `-n 50` means read lines 1 to 50.
 `-n 10, 50` means read lines 10 to 50.
 The special symbol `$` is interpreted as "last line", so `-n 10,$` means reads from line 10 to the end.
 
-==== `-max_percent_error`
+==== `-max_percent_error mpe`
 
-The `-max_percent_error` option is used by the loader process to decide when to automatically abort a running loading job.
-This depends on a user provided percentage of the data input lines that are rejected.
+The `-max_percent_error` option instructs the loader process to abort the loading job if the percentage of data lines in the input batch that are rejected exceeds `mpe`.
+By default, `mbe` is set to 100 and loading will continue until complete.
+
+Otherwise, for example, if the input source has 1000 data lines and `mpe` = 25 (or 25%),
+then the loading job will abort if it rejects 251 lines.
+
+If mpe = 0, then the load job aborts if any input line is rejected.
 
 There are two possible cases where an input line may be rejected:
 
-* Input format error: This is the case where the input line cannot be parsed properly.
-* Filtering error: This is the case where the input line can be parsed properly, but it does not pass certain filtering rules defined in the loading job itself.
-
-For example, if `-max_percent_error` is set to 50%, and over 50% of data input lines in a given batch are rejected by the loader either due to parsing error or filtering error, the loader process will abort itself.
-
-NOTE: The default percentage is set to 0.
-
-.`-max_percent_error` summery
-[cols="2"]
-|===
-|max_percent_error |behavior
-
-|0 |Loading will stop if any parsed input lines are rejected by the format or filtering rules.
-
-|between 0 and 99 |Loading will stop if the percentage of rejected parsed input exceeds the user-provided limit.
-
-|100 |Loading will continue until complete.
-|===
+* Input format error: the input line cannot be parsed properly.
+* Filtering error: the input line can be parsed properly, but it does not pass certain filtering rules defined in the loading job itself.
 
 === Parameters
 


### PR DESCRIPTION
Associated task: https://graphsql.atlassian.net/browse/DOC-1861 

This PR changes:
-Added the -max_loading_error option to the loading job command documentation 

Link to current documentation: https://docs.tigergraph.com/gsql-ref/current/ddl-and-loading/running-a-loading-job#_run_loading_job 