### PR TITLE
Modify the `find_degree_of_cats` indentation so that `find_degree_of_cats` is easier to understand.

### DIFF
--- a/modules/appendix/examples/social_net/controlflow_break.gsql
+++ b/modules/appendix/examples/social_net/controlflow_break.gsql
@@ -7,16 +7,20 @@ CREATE QUERY find_degree_of_cats(VERTEX<Person> seed) FOR GRAPH Social_Net
     friends (ANY) = {seed};
     WHILE @@found_cat_post != true AND friends.size() > 0 DO
         posts = SELECT v FROM friends-(Posted>:e)-:v
-            ACCUM CASE WHEN v.subject == "cats" THEN @@found_cat_post += true END;
-            IF @@found_cat_post THEN
+            ACCUM CASE WHEN v.subject == "cats" THEN
+                @@found_cat_post += true
+            END;
+
+        IF @@found_cat_post THEN
             BREAK;
+        END;
+
+        friends = SELECT v FROM friends-(Friend:e)-:v
+            WHERE v.@visited == false
+            ACCUM v.@visited = true;
+
+        @@degree += 1;
     END;
 
-    friends = SELECT v FROM friends-(Friend:e)-:v
-        WHERE v.@visited == false
-        ACCUM
-            v.@visited = true;
-            @@degree += 1;
-    END;
     PRINT @@degree;
 }


### PR DESCRIPTION
The previous version of this query has some bits of indentations that made it hard for me to understand and it took me some time + editing the indentation of the query myself to verify that the query seems valid.

The current version of this query looks like [the one](https://docs.tigergraph.com/gsql-ref/current/querying/control-flow-statements#_examples_4) seen on this page.


Therefore, to prevent future reader's confusion when going through this query, I decided to submit a pull request with a slightly modified version of this `find_degree_of_cats` query that should have less confusing indentations.

Please let me know if you need me to do anything else!