### PR TITLE
[DOC-2224] fix(optimizer): histogram endpoint updated;

### DIFF
--- a/modules/gsql-v2/querying/pages/query-optimizer/enable-cost-optimizer.adoc
+++ b/modules/gsql-v2/querying/pages/query-optimizer/enable-cost-optimizer.adoc
@@ -63,43 +63,49 @@ You need the following histogram statistics:
 ** `creationDate` attribute of type `LIKES` from `Person` to `Comment`.
 
 === Compute cardinality data
-To compute cardinality data (the count of each type), use the xref:query-optimizer/stats-api.adoc#_compute_cardinality_statistics[`POST :14240/gsqlserver/gsql/stats/card` endpoint].
+To compute cardinality data (the count of each type), use the xref:query-optimizer/stats-api.adoc#_compute_cardinality_statistics[`POST :14240/gsql/v1/stats/cardinality` endpoint].
 
 For example, to compute the cardinality data of the vertex `Person` in graph `ldbc_snb`, make the following request:
 
 [source.wrap,console]
 ----
-curl -s --user tigergraph:tigergraph -X POST "http://localhost:14240/gsqlserver/gsql/stats/card?graph=ldbc_snb&vertex=Person"
+curl -s --user tigergraph:tigergraph \
+-H 'Content-Type: application/json' \
+-X POST "http://localhost:14240/gsql/v1/stats/card?graph=ldbc_snb&vertex=Person"
 ----
 
 For another example, to compute the cardinality data of the refined edge type `LIKES` from a `Person` vertex to a `Comment` vertex, make the following request:
 
 [.wrap,console]
 ----
-curl -s --user tigergraph:tigergraph -X POST "http://localhost:14240/gsqlserver/gsql/stats/card?graph=ldbc_snb&edge=LIKES&from=Person&to=Comment"
+curl -s --user tigergraph:tigergraph \
+-H 'Content-Type: application/json' \
+-X POST "http://localhost:14240/gsql/v1/stats/card?graph=ldbc_snb&edge=LIKES&from=Person&to=Comment"
 ----
 
 For best results, compute the cardinality data for every type you identified in the previous step, each with its own request.
 
 === Compute histogram data
-To compute histogram data, use the xref:query-optimizer/stats-api.adoc#_compute_histogram_statistics[`POST :14240/gsqlserver/gsql/stats/histogram` endpoint].
+To compute histogram data, use the xref:query-optimizer/stats-api.adoc#_compute_histogram_statistics[`POST :14240/gsql/v1/stats/histogram` endpoint].
 
 For example, to compute the histogram data for attribute `gender` of vertex type `Person` on graph `ldbc_snb`, make the following request:
 
 [.wrap,console]
 ----
-$ $ curl --user tigergraph:tigergraph -X POST \
-"http://localhost:14240/gsqlserver/gsql/stats/histogram" \
--d '{"graph":"ldbc_snb", "vertex":"Person", "attribute":"gender", "buckets":10}'
+$ $ curl --user tigergraph:tigergraph \
+-H 'Content-Type: application/json' \
+-X POST "http://localhost:14240/gsql/v1/stats/histogram" \
+-d '{"graph":"ldbc_snb", "vertex":"Person", "attribute":"gender", "bucket":10}'
 ----
 
 To compute the histogram data for attribute `creationDate` of refined edge type `LIKES` from vertex type `Person` to vertex type `Comment`, make the following request:
 
 [.wrap,console]
 ----
-$ curl -s --user tigergraph:tigergraph -X POST \
-"http://localhost:14240/gsqlserver/gsql/stats/histogram" \
--d '{"graph":"ldbc_snb", "edge":"LIKES", "from":"Person", "to":"Comment", "attribute":"creationDate", "buckets":10}' | jq .
+$ curl -s --user tigergraph:tigergraph \
+-H 'Content-Type: application/json' \
+-X POST "http://localhost:14240/gsql/v1/stats/histogram" \
+-d '{"graph":"ldbc_snb", "edge":"LIKES", "from":"Person", "to":"Comment", "attribute":"creationDate", "bucket":10}' | jq .
 ----
 
 For best results, compute the histogram data for every attribute referenced in a `WHERE` clause of a `SELECT` statement.

--- a/modules/gsql-v2/querying/partials/cardinality-api.adoc
+++ b/modules/gsql-v2/querying/partials/cardinality-api.adoc
@@ -1,10 +1,12 @@
 [#_compute_cardinality_statistics]
 === Compute cardinality statistics
 
-`POST :14240/gsqlserver/gsql/stats/card`
+`POST :14240/gsql/v1/stats/cardinality`
 
 This endpoint computes the cardinality statistics for the vertex and edge types specified in the request.
 The cardinality statistics describe the number of vertices of a specified type, and the number of edges of a specified type between a specified pair of vertex types.
+
+The following header is also required: `-H 'Content-Type: application/json'`
 
 ==== Parameters
 
@@ -45,19 +47,23 @@ The following request computes cardinality for vertex type `Person` in the graph
 
 [.wrap,console]
 ----
-curl -s --user tigergraph:tigergraph -X POST "http://localhost:14240/gsqlserver/gsql/stats/card?graph=ldbc_snb&vertex=Person"
+curl -s --user tigergraph:tigergraph \
+-H 'Content-Type: application/json' \
+-X POST "http://localhost:14240/gsql/v1/stats/cardinality?graph=ldbc_snb&vertex=Person"
 ----
 
 The following request computes cardinality for edge type `LIKES` from `Person` to `Post` in the graph `ldbc_snb`:
 
 [.wrap,console]
 ----
-curl -s --user tigergraph:tigergraph -X POST "http://localhost:14240/gsqlserver/gsql/stats/card?graph=ldbc_snb&edge=LIKES&from=Person&to=Post"
+curl -s --user tigergraph:tigergraph \
+-H 'Content-Type: application/json' \
+-X POST "http://localhost:14240/gsql/v1/stats/cardinality?graph=ldbc_snb&edge=LIKES&from=Person&to=Post"
 ----
 
 === Retrieve cardinality statistics
 
-`GET :14240/gsqlserver/gsql/stats/card`
+`GET :14240/gsql/v1/stats/cardinality`
 
 This endpoint retrieves the cardinality statistics of a graph.
 
@@ -79,12 +85,14 @@ The following request retrieves the cardinality data for graph `ldbc_snb`:
 
 [.wrap,console]
 ----
-curl -s --user tigergraph:tigergraph -X GET "http://localhost:14240/gsqlserver/gsql/stats/card?graph=ldbc_snb"
+curl -s --user tigergraph:tigergraph \
+-H 'Content-Type: application/json' \
+-X GET "http://localhost:14240/gsql/v1/stats/cardinality?graph=ldbc_snb"
 ----
 
 === Delete cardinality statistics
 
-`DELETE :14240/gsqlserver/gsql/stats/card`
+`DELETE :14240/gsql/v1/stats/cardinality`
 
 This endpoint deletes the cardinality statistics of a graph.
 
@@ -106,5 +114,7 @@ The following request deletes the cardinality data for graph `ldbc_snb`:
 
 [.wrap,console]
 ----
-curl -s --user tigergraph:tigergraph -X DELETE "http://localhost:14240/gsqlserver/gsql/stats/card?graph=ldbc_snb"
+curl -s --user tigergraph:tigergraph \
+-H 'Content-Type: application/json' \
+-X DELETE "http://localhost:14240/gsql/v1/stats/cardinality?graph=ldbc_snb"
 ----

--- a/modules/gsql-v2/querying/partials/histogram-api.adoc
+++ b/modules/gsql-v2/querying/partials/histogram-api.adoc
@@ -1,16 +1,20 @@
 [#_compute_histogram_statistics]
 === Compute histogram statistics
 
-`POST :14240/gsqlserver/gsql/stats/histogram`
+`POST :14240/gsql/v1/stats/histogram`
 
 This endpoint computes histograms for a specified attribute of a vertex or edge type.
 
 READ_SCHEMA privilege is required for the graph that the histogram attribute belongs to. When gathering for multiple graphs at once (see Compute Multiple Histograms in one request), READ_SCHEMA is required on ALL of those graphs.
 
+The following header is also required: `-H 'Content-Type: application/json'`
+
 ==== Parameters
-Options can be specified in the header using -H:
+Additional options can be specified in the header using -H:
 `GSQL-Timeout` indicates timeout for the request. In the case of multiple computations, this timeout covers the overall timeout, including all the histogram computations.
 `GSQL-Thread-Limit` indicates the thread limit per histogram computation. In the case of multiple computations this thread limit will apply to each histogram computation individually.
+
+Note that multiple headers can be included, for example: `-H 'Content-Type: application/json' -H 'GSQL-Timeout: 1000000' ...`
 
 ==== Request body
 
@@ -95,7 +99,8 @@ Histogram Computation Request::
 [source.wrap,console]
 ----
 $ curl --user tigergraph:tigergraph \
--X POST "http://localhost:14240/gsqlserver/gsql/stats/histogram" \
+-H 'Content-Type: application/json' \
+-X POST "http://localhost:14240/gsql/v1/stats/histogram" \
 -d '{"graph":"test_graph","vertex":"Comment","attribute":"length","bucket":10}'
 ----
 --
@@ -130,7 +135,8 @@ Histogram Computation Request::
 [source.wrap,console]
 ----
 $ curl --user tigergraph:tigergraph \
--X POST "http://localhost:14240/gsqlserver/gsql/stats/histogram" \
+-H 'Content-Type: application/json' \
+-X POST "http://localhost:14240/gsql/v1/stats/histogram" \
 -d '{"graph":"test_graph","edge":"COMP_MEMBER","from":"compForum","to":"compPerson","attribute":"joinDate","bucket":10}'
 ----
 --
@@ -209,7 +215,8 @@ Histogram Computation Request::
 [source.wrap,console]
 ----
 $ curl --user tigergraph:tigergraph \
--X POST "http://localhost:14240/gsqlserver/gsql/stats/histogram" \
+-H 'Content-Type: application/json' \
+-X POST "http://localhost:14240/gsql/v1/stats/histogram" \
 -d '{}'
 ----
 --
@@ -239,7 +246,7 @@ A more condensed error message will be provided under `failure` if any of the hi
 
 `READ_DATA` privilege is required to retrieve a histogram for a particular attribute. This can be at the attribute level or a higher level. Note that for edge-based histograms, the 'from' and 'to' vertex are not read and therefore only the edge requires the privilege.
 
-`GET :14240/gsqlserver/gsql/stats/histogram`
+`GET :14240/gsql/v1/stats/histogram`
 
 This endpoint retrieves histogram data for a specified attribute of a vertex or edge type. Empty buckets in the histogram are denoted by a totalCount, upperCount, and ndv of zero. The upperBound will have the max theoretical value for an empty bucket.
 
@@ -285,7 +292,8 @@ Histogram Retrieval Request::
 [source.wrap,console]
 ----
 $ curl --user tigergraph:tigergraph \
--X GET "http://localhost:14240/gsqlserver/gsql/stats/histogram" \
+-H 'Content-Type: application/json' \
+-X GET "http://localhost:14240/gsql/v1/stats/histogram" \
 -d '{"graph":"test_graph","vertex":"Comment","attribute":"length","bucket":10}'
 ----
 --
@@ -393,7 +401,8 @@ Histogram Retrieval Request::
 [source.wrap,console]
 ----
 $ curl --user tigergraph:tigergraph \
--X GET "http://localhost:14240/gsqlserver/gsql/stats/histogram" \
+-H 'Content-Type: application/json' \
+-X GET "http://localhost:14240/gsql/v1/stats/histogram" \
 -d '{"graph":"test_graph","edge":"COMP_MEMBER","from":"compForum","to":"compPerson","attribute":"joinDate","bucket":10}'
 ----
 --
@@ -495,7 +504,7 @@ Results Histogram Does Not Exist::
 
 === Delete histogram statistics
 
-`DELETE :14240/gsqlserver/gsql/stats/histogram`
+`DELETE :14240/gsql/v1/stats/histogram`
 
 This endpoint deletes histogram data for a graph.
 This includes histogram data on all vertex attributes in that graph.
@@ -542,7 +551,8 @@ Histogram Deletion Request::
 [source.wrap,console]
 ----
 $ curl --user tigergraph:tigergraph \
--X DELETE "http://localhost:14240/gsqlserver/gsql/stats/histogram" \
+-H 'Content-Type: application/json' \
+-X DELETE "http://localhost:14240/gsql/v1/stats/histogram" \
 -d '{"graph":"test_graph","vertex":"Comment","attribute":"length"}'
 ----
 --
@@ -570,7 +580,8 @@ Histogram Deletion Request::
 [source.wrap,console]
 ----
 $ curl --user tigergraph:tigergraph \
--X DELETE "http://localhost:14240/gsqlserver/gsql/stats/histogram" \
+-H 'Content-Type: application/json' \
+-X DELETE "http://localhost:14240/gsql/v1/stats/histogram" \
 -d '{"graph":"test_graph","edge":"COMP_MEMBER","from":"compForum","to":"compPerson","attribute":"joinDate"}'
 ----
 --


### PR DESCRIPTION
[DOC-2224](https://graphsql.atlassian.net/browse/DOC-2224) Programmable restapi made some changes to endpoint path and how we call endpoints

* Updated gsqlserver/gsql -> gsql/v1
* buckets -> bucket
* Added new required header

[DOC-2224]: https://graphsql.atlassian.net/browse/DOC-2224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ