### PR TITLE
[DOC-2121] feat(gsql): support using vertex variable as seed of vset (4.1.0)

### DIFF
--- a/modules/appendix/examples/social_net/declaration_vertex_set_example.gsql
+++ b/modules/appendix/examples/social_net/declaration_vertex_set_example.gsql
@@ -1,6 +1,7 @@
 CREATE QUERY seed_set_example (VERTEX v1, VERTEX<Person> v2, SET<VERTEX> v3, SET<VERTEX<Person>> v4) FOR GRAPH Social_Net {
     SetAccum<VERTEX> @@test_set;
     SetAccum<VERTEX<Person>> @@test_set2;
+    VERTEX v5 = to_vertex("person1", "Person");  // vertex variable
     S1 = { v1 };    // Untyped vertex parameter enclosed in curly brackets
     S2 = { v2 };    // Typed vertex parameter enclosed in curly brackets
     S3 = v3;                       // Untyped vertex set parameter
@@ -18,4 +19,5 @@ CREATE QUERY seed_set_example (VERTEX v1, VERTEX<Person> v2, SET<VERTEX> v3, SET
                                  // Inside curly brackets cannot be put another
                                  // Seedset, e.g., S1
     S13 = S11 UNION S12;           // But we can use UNION to combine S1
+    S14 = { v5 };                  // Vertex variable enclosed in curly brackets
 }

--- a/modules/querying/pages/declaration-and-assignment-statements.adoc
+++ b/modules/querying/pages/declaration-and-assignment-statements.adoc
@@ -36,6 +36,7 @@ seed := '_'
       | vertexType ".*"
       | paramName
       | "SelectVertex" selectVertParams
+      | vertexVarName
 
 selectVertParams := "(" filePath "," columnId "," (columnId | name) ","
           stringLiteral "," (TRUE | FALSE) ")" ["." FILTER "(" condition ")"]
@@ -340,6 +341,7 @@ seed := '_'
       | vertexType ".*"
       | paramName
       | "SelectVertex" selectVertParams
+      | vertexVarName
 
 selectVertParams := "(" filePath "," columnId "," (columnId | name) ","
      stringLiteral "," (TRUE | FALSE) ")" ["." FILTER "(" condition ")"]
@@ -358,6 +360,7 @@ The query below lists all ways of assigning a vertex set variable an initial set
 * Copy of another vertex set
 * A combination of individual vertices, vertex set parameters, or base type variables, enclosed in curly brackets
 * Union of vertex set variables
+* A vertex variable enclosed in curly brackets
 
 .Vertex set example
 [source.wrap,gsql]


### PR DESCRIPTION
[DOC-2121](https://graphsql.atlassian.net/browse/DOC-2121)
Support using vertex variable as seed of vset

[DOC-2121]: https://graphsql.atlassian.net/browse/DOC-2121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ