### PR TITLE
[DOC-2105] fix(gsql): add warnings for blocked to_vertex and to_vertex_set usage in ACCUM and POST-ACCUM;

### DIFF
--- a/modules/querying/pages/func/vertex-methods.adoc
+++ b/modules/querying/pages/func/vertex-methods.adoc
@@ -1172,7 +1172,7 @@ GSQL > RUN QUERY to_vertex_test("Dan", "person")
 
 [WARNING]
 ==== 
-Since 4.1.0, we cannot use `to_vertex_set()` in ACCUM or POST-ACCUM clauses any more. An error message will be prompted when we try to do so.
+Since v4.1.0, `to_vertex_set()` may not be used in ACCUM or POST-ACCUM clauses.
 
 ====  Example
 

--- a/modules/querying/pages/func/vertex-methods.adoc
+++ b/modules/querying/pages/func/vertex-methods.adoc
@@ -1074,6 +1074,8 @@ Running `to_vertex() and to_vertex_set()` requires real-time conversion of an ex
 
 * If the user can always know the id before running the query, define the query with `VERTEX` or `SET<VERTEX>` parameters instead of `STRING` or `SET<STRING>` parameters, and avoid calling `to_vertex()` or `to_vertex_set()`.
 * Calling `to_vertex_set()` one time is much faster than calling `to_vertex()` multiple times. Use `to_vertex_set()` instead of `to_vertex()` as much as possible.
+
+Since 4.1.0, we cannot use `to_vertex()` in ACCUM or POST-ACCUM clauses any more. An error message will be prompted when we try to do so.
 ==== 
 
 
@@ -1143,6 +1145,11 @@ GSQL > RUN QUERY to_vertex_test("Dan", "person")
 
 
 === `to_vertex_set()`
+
+[WARNING]
+==== 
+Since 4.1.0, we cannot use `to_vertex_set()` in ACCUM or POST-ACCUM clauses any more. An error message will be prompted when we try to do so.
+==== 
 
 
 ====  Syntax

--- a/modules/querying/pages/func/vertex-methods.adoc
+++ b/modules/querying/pages/func/vertex-methods.adoc
@@ -1076,6 +1076,30 @@ Running `to_vertex() and to_vertex_set()` requires real-time conversion of an ex
 * Calling `to_vertex_set()` one time is much faster than calling `to_vertex()` multiple times. Use `to_vertex_set()` instead of `to_vertex()` as much as possible.
 
 Since 4.1.0, we cannot use `to_vertex()` in ACCUM or POST-ACCUM clauses any more. An error message will be prompted when we try to do so.
+
+====  Example
+
+.Example query using to_vertex() in Accum should propmt an error message
+
+[source,gsql]
+----
+CREATE QUERY myTest() {
+    ListAccum<VERTEX> @@myVertices;
+    vSet = SELECT src from Person:src
+      Accum
+        @@myVertices += to_vertex("m1","Person")    # such use case should not be allowed anymore
+    ;
+}
+----
+
+You should receive a similar error message.
+
+[source,text]
+----
+Using a vertex function 'to_vertex' or 'to_vertex_set' in ACCUM/POST-ACCUM,
+this has been deprecated. Please rewrite your query.
+----
+
 ==== 
 
 
@@ -1149,8 +1173,31 @@ GSQL > RUN QUERY to_vertex_test("Dan", "person")
 [WARNING]
 ==== 
 Since 4.1.0, we cannot use `to_vertex_set()` in ACCUM or POST-ACCUM clauses any more. An error message will be prompted when we try to do so.
-==== 
 
+====  Example
+
+.Example query using to_vertex_set() in Accum should propmt an error message
+
+[source,gsql]
+----
+CREATE QUERY myTest2(SET<String> myIds) {
+    SetAccum<VERTEX> @@myVertices;
+    vSet = SELECT src from Person:src
+      Accum
+        @@myVertices += to_vertex_set(myIds, "Person")    # such use case should not be allowed anymore
+    ;
+}
+----
+
+You should receive a similar error message.
+
+[source,text]
+----
+Using a vertex function 'to_vertex' or 'to_vertex_set' in ACCUM/POST-ACCUM,
+this has been deprecated. Please rewrite your query.
+----
+
+==== 
 
 ====  Syntax
 

--- a/modules/querying/pages/func/vertex-methods.adoc
+++ b/modules/querying/pages/func/vertex-methods.adoc
@@ -1075,7 +1075,7 @@ Running `to_vertex() and to_vertex_set()` requires real-time conversion of an ex
 * If the user can always know the id before running the query, define the query with `VERTEX` or `SET<VERTEX>` parameters instead of `STRING` or `SET<STRING>` parameters, and avoid calling `to_vertex()` or `to_vertex_set()`.
 * Calling `to_vertex_set()` one time is much faster than calling `to_vertex()` multiple times. Use `to_vertex_set()` instead of `to_vertex()` as much as possible.
 
-Since 4.1.0, we cannot use `to_vertex()` in ACCUM or POST-ACCUM clauses any more. An error message will be prompted when we try to do so.
+Since v4.1.0, `to_vertex()` may not be used in ACCUM or POST-ACCUM clauses.
 
 ====  Example
 


### PR DESCRIPTION
[DOC-2105](https://graphsql.atlassian.net/browse/DOC-2105)
Add warnings for blocked to_vertex and to_vertex_set usage in ACCUM and POST-ACCUM

[DOC-2105]: https://graphsql.atlassian.net/browse/DOC-2105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ