### PR TITLE
Update example-graphs.adoc

### DIFF
--- a/modules/appendix/pages/example-graphs.adoc
+++ b/modules/appendix/pages/example-graphs.adoc
@@ -44,7 +44,7 @@ CREATE LOADING JOB load_member_company FOR GRAPH Work_Net {
 }
 
 RUN LOADING JOB load_member USING f="./persons"
-RUN LOADING JOB load_company USING f="./companies"
+RUN LOADING JOB load_company USING f="./company"
 RUN LOADING JOB load_member_company USING f="./person_company"
 ----
 


### PR DESCRIPTION
Typo in file name. changed from `companies` to `company`