### PR TITLE
DOC-2388-optional-match and table layout improvements

### DIFF
--- a/modules/openCypher-in-gsql/pages/index.adoc
+++ b/modules/openCypher-in-gsql/pages/index.adoc
@@ -15,7 +15,7 @@ From version 4.1.2, certain restrictions on the `MATCH` and `WITH` clauses have 
 == openCypher Features in GSQL
 === Clauses
 
-[cols="1,1"]
+[cols="1,2"]
 |===
 |Clause |Description
 
@@ -35,6 +35,8 @@ See below for restrictions before version *4.1.2*.
 
 |MANDATORY MATCH |Reading Specify the patterns to search for in the database, and fail if no match is found.
 
+|OPTIONAL MATCH |Reading Specify the patterns to search for in the database while using nulls for missing parts of the pattern.
+
 |ORDER BY [ASC[ENDING] DESC[ENDING]] |Reading sub-clause A sub-clause following
 
 |RETURN or WITH |Specifying that the output should be sorted in either ascending (the default) or descending order.
@@ -43,16 +45,18 @@ See below for restrictions before version *4.1.2*.
 
 |SKIP |Reading/Writing A sub-clause defining from which record to start including the records in the output.
 
+|WHERE |Reading sub-clause A sub-clause used to add constraints to the patterns in a MATCH clause, or to filter the results of a WITH clause.
+
 |WITH … [AS] |Projecting Allows query parts to be chained together, piping the results from one to be used as starting points or criteria in the next.
 
 See below for restrictions before version *4.1.2*.
-
-|WHERE |Reading sub-clause A sub-clause used to add constraints to the patterns in a MATCH clause, or to filter the results of a WITH clause.
 |===
 
 === Operators
-[cols="1,1"]
+[cols="1,3"]
 |===
+|Operator |Description
+
 |% |Mathematical Modulo division
 
 |* |Mathematical Multiplication
@@ -112,131 +116,135 @@ See below for restrictions before version *4.1.2*.
 
 === Functions
 
-[cols="1,1"]
+[%autowidth]
 |===
-|abs() |Numeric Returns the absolute value of a number.
+|Operator | Value type | Description
 
-|acos() |Trigonometric Returns the arccosine of a number in radians.
+|abs() |Numeric | Returns the absolute value of a number.
 
-|asin() |Trigonometric Returns the arcsine of a number in radians.
+|acos() |Numeric | Returns the arccosine of a number in radians.
 
-|atan() |Trigonometric Returns the arctangent of a number in radians.
+|asin() |Numeric | Returns the arcsine of a number in radians.
 
-|atan2() |Trigonometric Returns the arctangent2 of a set of coordinates in radians.
+|atan() |Numeric | Returns the arctangent of a number in radians.
 
-|avg() |Aggregating Returns the average of a set of numeric values.
+|atan2() |Numeric | Returns the arctangent2 of a set of coordinates in radians.
 
-|ceil() |Numeric Returns the smallest floating point number that is greater than or equal to a number and equal to a mathematical integer.
+|avg() |Numeric | Returns the average of a set of numeric values.
 
-|coalesce() |Scalar Returns the first non-null value in a list of expressions.
+|ceil() |Numeric | eturns the smallest floating point number that is greater than or equal to a number and equal to a mathematical integer.
 
-|cos() |Trigonometric Returns the cosine of a number.
+|coalesce() |Scalar |Returns the first non-null value in a list of expressions.
 
-|cot() |Trigonometric Returns the cotangent of a number.
+|cos() |Numeric | Returns the cosine of a number.
 
-|count() |Aggregating Returns the number of values or records.
+|cot() |Numeric | Returns the cotangent of a number.
 
-|degrees() |Trigonometric Converts radians to degrees.
+|count() |Numeric | Returns the number of values or records.
 
-|e() |Logarithmic Returns the base of the natural logarithm, e.
+|degrees() |Numeric | Converts radians to degrees.
 
-|elementId() |Scalar Returns the String id of a relationship or node.
+|e() |Numeric | Returns the base of the natural logarithm, e.
 
-|exp() |Logarithmic Returns e^n, where e is the base of the natural logarithm, and n is the value of the argument expression.
+|elementId() |Scalar |Returns the String id of a relationship or node.
 
-|floor() |Numeric Returns the largest floating point number that is less than or equal to a number and equal to a mathematical integer.
+|exp() |Numeric | Returns e^n, where e is the base of the natural logarithm, and n is the value of the argument expression.
 
-|head() |Scalar Returns the first element in a list.
+|floor() |Numeric | Returns the largest floating point number that is less than or equal to a number and equal to a mathematical integer.
 
-|id() |Scalar Returns the id of a relationship or node.
+|head() |Scalar |Returns the first element in a list.
 
-|last() |Scalar Returns the last element in a list.
+|id() |Scalar |Returns the id of a relationship or node.
 
-|left() |String Returns a string containing the specified number of leftmost characters of the original string.
+|labels() |List |Returns a list containing the string representations for all the labels of a node.
 
-|log() |Logarithmic Returns the natural logarithm of a number.
+|last() |Scalar |Returns the last element in a list.
 
-|log10() |Logarithmic Returns the common logarithm (base 10) of a number.
+|left() |String |Returns a string containing the specified number of leftmost characters of the original string.
 
-|lTrim() |String Returns the original string with leading whitespace removed.
+|log() |Numeric | Returns the natural logarithm of a number.
 
-|labels() |List Returns a list containing the string representations for all the labels of a node.
+|log10() |Numeric | Returns the common logarithm (base 10) of a number.
 
-|max() |Aggregating Returns the maximum value in a set of values.
+|lTrim() |String |Returns the original string with leading whitespace removed.
 
-|min() |Aggregating Returns the minimum value in a set of values.
 
-|pi() |Trigonometric Returns the mathematical constant pi.
+|max() |Numeric | Returns the maximum value in a set of values.
 
-|radians() |Trigonometric Converts degrees to radians.
+|min() |Numeric | Returns the minimum value in a set of values.
 
-|rand() |Numeric Returns a random floating point number in the range from 0 (inclusive) to 1 (exclusive); i.e. [0, 1).
+|pi() |Numeric | Returns the mathematical constant pi.
 
-|range() |List Returns a list comprising all integer values within a specified range.
+|radians() |Numeric | Converts degrees to radians.
 
-|replace() |String Returns a string in which all occurrences of a specified string in the original string have been replaced by another (specified) string.
+|rand() |Numeric | Returns a random floating point number in the range from 0 (inclusive) to 1 (exclusive); i.e. [0, 1).
 
-|reverse() |String Returns a string in which the order of all characters in the original string have been reversed.
+|range() |List |Returns a list comprising all integer values within a specified range.
 
-|right() |String Returns a string containing the specified number of rightmost characters of the original string.
+|replace() |String |Returns a string in which all occurrences of a specified string in the original string have been replaced by another (specified) string.
 
-|round() |Numeric Returns the value of a number rounded to the nearest integer.
+|reverse() |String |Returns a string in which the order of all characters in the original string have been reversed.
 
-|rTrim() |String Returns the original string with trailing whitespace removed.
+|right() |String |Returns a string containing the specified number of rightmost characters of the original string.
 
-|sign() |Numeric Returns the signum of a number: 0 if the number is 0, -1 for any negative number, and 1 for any positive number.
+|round() |Numeric |Returns the value of a number rounded to the nearest integer.
 
-|sin() |Trigonometric Returns the sine of a number.
+|rTrim() |String |Returns the original string with trailing whitespace removed.
 
-|size() |Scalar Returns the number of items in a list. (When applied to a list)
+|sign() |Numeric |Returns the signum of a number: 0 if the number is 0, -1 for any negative number, and 1 for any positive number.
 
-|split() |String Returns a list of strings resulting from the splitting of the original string around matches of the given delimiter.
+|sin() |Numeric | Returns the sine of a number.
 
-|sqrt() |Logarithmic Returns the square root of a number.
+|size() |Numeric | Returns the number of items in a list. (When applied to a list)
 
-|stDev() |Aggregating Returns the standard deviation for the given value over a group for a sample of a population.
+|split() |List |Returns a list of strings resulting from the splitting of the original string around matches of the given delimiter.
 
-|stDevP() |Aggregating Returns the standard deviation for the given value over a group for an entire population
+|sqrt() |Numeric | Returns the square root of a number.
 
-|substring() |String Returns a substring of the original string, beginning with a 0-based index start and length.
+|stDev() |Numeric | Returns the standard deviation for the given value over a group for a sample of a population.
 
-|sum() |Aggregating Returns the sum of a set of numeric values.
+|stDevP() |Numeric | Returns the standard deviation for the given value over a group for an entire population
 
-|tail() |List Returns all but the first element in a list.
+|substring() |String |Returns a substring of the original string, beginning with a 0-based index start and length.
 
-|tan() |Trigonometric Returns the tangent of a number.
+|sum() |Numeric | Returns the sum of a set of numeric values.
 
-|timestamp() |Scalar Returns the difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC.
+|tail() |List |Returns all but the first element in a list.
 
-|trim() |String Returns the original string with leading and trailing whitespace removed.
+|tan() |Numeric | Returns the tangent of a number.
 
-|type() |Scalar Returns the string representation of the relationship type.
+|timestamp() |Scalar |Returns the difference, measured in milliseconds, between the current time and midnight, January 1, 1970 UTC.
 
-|toLower() |String Returns the original string in lowercase.
+|trim() |String |Returns the original string with leading and trailing whitespace removed.
 
-|toString() |String Converts an integer, float or boolean value to a string.
+|toLower() |String |Returns the original string in lowercase.
 
-|toUpper() |String Returns the original string in uppercase.
+|toString() |String |Converts an integer, float or boolean value to a string.
 
-|toBoolean() |Scalar Converts a string value to a boolean value.
+|toUpper() |String |Returns the original string in uppercase.
 
-|toFloat() |Scalar Converts an integer or string value to a floating point number.
+|toBoolean() |Scalar |Converts a string value to a boolean value.
 
-|toInteger() |Scalar Converts a floating point or string value to an integer value.
+|toFloat() |Scalar |Converts an integer or string value to a floating point number.
 
+|toInteger() |Scalar |Converts a floating point or string value to an integer value.
+
+|type() |Scalar |Returns the string representation of the relationship type.
 |===
 
 === Expressions
-[cols="1,1"]
+[cols="1,3"]
 |===
-|CASE Expression |A generic conditional expression, similar to if/else statements available in other languages.
+|Expression |Description
+
+|CASE |A generic conditional expression, similar to if/else statements available in other languages.
 |===
 
 == openCypher Features Not Yet Supported
 === Clauses
-[cols="1,1]
+[cols="1,3"]
 |===
-|OPTIONAL MATCH |Reading Specify the patterns to search for in the database while using nulls for missing parts of the pattern.
+|Clause |Description
 
 |CALL […YIELD] |Reading/Writing Invoke a procedure deployed in the database.
 
@@ -246,51 +254,51 @@ See below for restrictions before version *4.1.2*.
 
 |REMOVE |Writing Remove properties and labels from nodes and relationships.
 
+|SET |Writing Update labels on nodes and properties on nodes and relationships.
+
 |UNION |Set operations Combines the result of multiple queries. Duplicates are removed.
 
 |UNION ALL |Set operations Combines the result of multiple queries. Duplicates are retained.
 
 |UNWIND … [AS] |Projecting Expands a list into a sequence of records.
-
-|SET |Writing Update labels on nodes and properties on nodes and relationships.
 |===
 
 === Operators
 N/A
 
 === Functions
-[cols="1,1"]
+
+[%autowidth]
 |===
+| Function | Value Type | Description
 
-|collect() |Aggregating Returns a list containing the values returned by an expression.
+|collect() |Numeric | Returns a list containing the values returned by an expression.
 
-|endNode() |Scalar Returns the end node of a relationship.
+|endNode() |Scalar |Returns the end node of a relationship.
 
-|exists() |Predicate Returns true if a match for the pattern exists in the graph, or if the specified property exists in the node, relationship or map.
+|exists() |Boolean | Returns true if a match for the pattern exists in the graph, or if the specified property exists in the node, relationship or map.
 
-|keys() |List Returns a list containing the string representations for all the property names of a node, relationship, or map.
+|keys() |List |Returns a list containing the string representations for all the property names of a node, relationship, or map.
 
-|length() |Scalar Returns the length of a path.
+|length() |Numeric | Returns the length of a path.
 
-|nodes() |List Returns a list containing all the nodes in a path.
+|nodes() |List |Returns a list containing all the nodes in a path.
 
-|percentileCont() |Aggregating Returns the percentile of the given value over a group using linear interpolation.
+|percentileCont() |Numeric | Returns the percentile of the given value over a group using linear interpolation.
 
-|percentileDisc() |Aggregating Returns the percentile of the given value over a group using a rounding method.
+|percentileDisc() |Numeric | Returns the percentile of the given value over a group using a rounding method.
 
-|properties() |Scalar Returns a map containing all the properties of a node or relationship.
+|properties() |Map | Returns a map containing all the properties of a node or relationship.
 
-|relationships() |List Returns a list containing all the relationships in a path.
+|relationships() |List |Returns a list containing all the relationships in a path.
 
-|reverse() |List Returns a list in which the order of all elements in the original list have been reversed.
+|reverse() |List |Returns a list in which the order of all elements in the original list have been reversed.
 
-|size() |Scalar Returns the number of subgraphs matching the pattern expression. (When applied to
-pattern expression)
+|size() of a pattern expression |Numeric | Returns the number of subgraphs matching the pattern expression.
 
-|size() |Scalar Returns the size of a string. (When applied to string)
+|size() of a string |Numeric | Returns the size of a string.
 
-|startNode() |Scalar Returns the start node of a relationship.
-
+|startNode() |Scalar |Returns the start node of a relationship.
 |===
 
 === Syntax


### PR DESCRIPTION
DOC-2388 has three OpenCypher changes, but one of these was accidentally omitted from the previous PRs.

1. Move OPTIONAL MATCH from the "Not Support" to the "Supported" table.

However, while looking at this page, I noticed some other things that could be improved:
2. The Function tables had information for 3 columns (name, type, description), but the information was being forced into 2 columns (name, type-description). I added the 3rd column.
3. Adjusted column widths to fit the text better.
4. Added headings to all the tables.
5. Fixed the alphabetic ordering of items in the tables.