### PR TITLE
Correct grammar in INSTALL QUERY instructions

### DIFF
--- a/modules/querying/pages/func/query-user-defined-functions.adoc
+++ b/modules/querying/pages/func/query-user-defined-functions.adoc
@@ -116,7 +116,7 @@ To re-enable them:
 
 . Check each disabled query to see if the UDF change causes a need to revise the query.  Make necessary modifications.
 . Run `CREATE OR REPLACE QUERY` for each disabled query.
-. Run `INSTALL QUERY`, singly or for a batch of queries.
+. Run `INSTALL QUERY`, single or for a batch of queries.
 ====
 
 === Use GitHub to store UDFs


### PR DESCRIPTION
typo - from 'singly' to 'single'